### PR TITLE
Change password length from int to uint

### DIFF
--- a/cmd/go-generate-password/main.go
+++ b/cmd/go-generate-password/main.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	rootCmd                    *cobra.Command
-	length                     int
+	length                     uint
 	characterSet               string
 	includeSymbols             bool
 	includeNumbers             bool
@@ -19,7 +19,7 @@ var (
 	includeUppercaseLetters    bool
 	excludeSimilarCharacters   bool
 	excludeAmbiguousCharacters bool
-	times                      int
+	times                      uint
 )
 
 func main() {
@@ -30,7 +30,7 @@ func main() {
 		Long:  "go-generate-password is a password generating engine written in Go.",
 	}
 
-	rootCmd.PersistentFlags().IntVarP(&length, "length", "l", generator.DefaultConfig.Length, "Length of the password")
+	rootCmd.PersistentFlags().UintVarP(&length, "length", "l", generator.DefaultConfig.Length, "Length of the password")
 	rootCmd.PersistentFlags().StringVar(&characterSet, "characters", generator.DefaultConfig.CharacterSet, "Character set for the config")
 	rootCmd.PersistentFlags().BoolVar(&includeSymbols, "symbols", generator.DefaultConfig.IncludeSymbols, "Include symbols")
 	rootCmd.PersistentFlags().BoolVar(&includeNumbers, "numbers", generator.DefaultConfig.IncludeNumbers, "Include numbers")
@@ -38,7 +38,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolVar(&includeUppercaseLetters, "uppercase", generator.DefaultConfig.IncludeSymbols, "Include uppercase letters")
 	rootCmd.PersistentFlags().BoolVar(&excludeSimilarCharacters, "exclude-similar", generator.DefaultConfig.ExcludeSimilarCharacters, "Exclude similar characters")
 	rootCmd.PersistentFlags().BoolVar(&excludeAmbiguousCharacters, "exclude-ambiguous", generator.DefaultConfig.ExcludeAmbiguousCharacters, "Exclude ambiguous characters")
-	rootCmd.PersistentFlags().IntVarP(&times, "times", "n", 1, "How many passwords to generate")
+	rootCmd.PersistentFlags().UintVarP(&times, "times", "n", 1, "How many passwords to generate")
 
 	err := rootCmd.Execute()
 	if err != nil {

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -9,16 +9,16 @@ import (
 
 const (
 	// LengthWeak weak length password
-	LengthWeak = 6
+	LengthWeak uint = 6
 
 	// LengthOK ok length password
-	LengthOK = 12
+	LengthOK uint = 12
 
 	// LengthStrong strong length password
-	LengthStrong = 24
+	LengthStrong uint = 24
 
 	// LengthVeryStrong very strong length password
-	LengthVeryStrong = 36
+	LengthVeryStrong uint = 36
 
 	// DefaultLetterSet is the letter set that is defaulted to - just the
 	// alphabet
@@ -73,7 +73,7 @@ type Generator struct {
 // what type of password to generate
 type Config struct {
 	// Length is the length of password to generate
-	Length int
+	Length uint
 
 	// CharacterSet is the setting to manually set the
 	// character set
@@ -191,7 +191,7 @@ func (g Generator) Generate() (*string, error) {
 	characterSet := strings.Split(g.Config.CharacterSet, "")
 	max := big.NewInt(int64(len(characterSet)))
 
-	for i := 0; i < g.Config.Length; i++ {
+	for i := uint(0); i < g.Config.Length; i++ {
 		val, err := rand.Int(rand.Reader, max)
 		if err != nil {
 			return nil, err
@@ -203,9 +203,9 @@ func (g Generator) Generate() (*string, error) {
 
 // GenerateMany generates multiple passwords with length set
 // in the config
-func (g Generator) GenerateMany(amount int) ([]string, error) {
+func (g Generator) GenerateMany(amount uint) ([]string, error) {
 	var generated []string
-	for i := 0; i < amount; i++ {
+	for i := uint(0); i < amount; i++ {
 		str, err := g.Generate()
 		if err != nil {
 			return nil, err
@@ -217,11 +217,11 @@ func (g Generator) GenerateMany(amount int) ([]string, error) {
 }
 
 // GenerateWithLength generate one password with set length
-func (g Generator) GenerateWithLength(length int) (*string, error) {
+func (g Generator) GenerateWithLength(length uint) (*string, error) {
 	var generated string
 	characterSet := strings.Split(g.Config.CharacterSet, "")
 	max := big.NewInt(int64(len(characterSet)))
-	for i := 0; i < length; i++ {
+	for i := uint(0); i < length; i++ {
 		val, err := rand.Int(rand.Reader, max)
 		if err != nil {
 			return nil, err
@@ -232,9 +232,9 @@ func (g Generator) GenerateWithLength(length int) (*string, error) {
 }
 
 // GenerateManyWithLength generates multiple passwords with set length
-func (g Generator) GenerateManyWithLength(amount, length int) ([]string, error) {
+func (g Generator) GenerateManyWithLength(amount, length uint) ([]string, error) {
 	var generated []string
-	for i := 0; i < amount; i++ {
+	for i := uint(0); i < amount; i++ {
 		str, err := g.GenerateWithLength(length)
 		if err != nil {
 			return nil, err

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -162,7 +162,7 @@ func TestGenerator_Generate(t *testing.T) {
 			name:   "valid",
 			fields: fields{&DefaultConfig},
 			test: func(pwd *string, characterSet string) {
-				assert.Len(t, *pwd, DefaultConfig.Length)
+				assert.Len(t, *pwd, int(DefaultConfig.Length))
 				err := stringMatchesCharacters(*pwd, characterSet)
 				if err != nil {
 					t.Errorf("Generate() error = %v", err)
@@ -189,7 +189,7 @@ func TestGenerator_GenerateMany(t *testing.T) {
 		Config *Config
 	}
 	type args struct {
-		amount int
+		amount uint
 	}
 	tests := []struct {
 		name    string
@@ -253,7 +253,7 @@ func TestGenerator_GenerateWithLength(t *testing.T) {
 		Config *Config
 	}
 	type args struct {
-		length int
+		length uint
 	}
 	tests := []struct {
 		name    string
@@ -294,8 +294,8 @@ func TestGenerator_GenerateManyWithLength(t *testing.T) {
 		Config *Config
 	}
 	type args struct {
-		amount int
-		length int
+		amount uint
+		length uint
 	}
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Change the variable types from int to uint for password length and number of generated strings. Done to avoid trying to have a password with a negative length